### PR TITLE
Tidy up TODOS

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
       fail-fast: false
     
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.20.5
+* Removed unused variable
+* Made `set_pair_cookies()` to merge user_claim Dict instead of relying on default value
+* Removed Python 3.8 from support due to the above Dict merge method
 ## 0.20.4
 * Upgraded cookie defaults to "safer" ones
 * `set_pair_cookies()` now 1st class citizen (though need to sort out user_claims still)

--- a/libre_fastapi_jwt/__init__.py
+++ b/libre_fastapi_jwt/__init__.py
@@ -1,5 +1,5 @@
 """FastAPI extension that provides JWT Auth support (secure, easy to use and lightweight)"""
 
-__version__ = "0.20.4"
+__version__ = "0.20.5"
 
 from .auth_jwt import AuthJWT

--- a/libre_fastapi_jwt/auth_jwt.py
+++ b/libre_fastapi_jwt/auth_jwt.py
@@ -361,7 +361,7 @@ class AuthJWT(AuthConfig):
         headers: Optional[Dict] = None,
         expires_time: Optional[Union[timedelta, int, bool]] = None,
         audience: Optional[Union[str, Sequence[str]]] = None,
-        user_claims: Optional[Dict] = {"aid": str(uuid4())},
+        user_claims: Optional[Dict] = {},
     ) -> str:
         """
         Create a refresh token with X days for expired time (default),
@@ -369,6 +369,8 @@ class AuthJWT(AuthConfig):
 
         :return: hash token
         """
+        # Create a unique identifier to allow consumers to associate both tokens created as pair
+        pair_identifier = {"aid": str(uuid4())}
 
         refresh = self._create_token(
             subject=subject,
@@ -377,7 +379,7 @@ class AuthJWT(AuthConfig):
             algorithm=algorithm,
             headers=headers,
             audience=audience,
-            user_claims=user_claims,
+            user_claims=user_claims | pair_identifier,
         )
         access = self._create_token(
             subject=subject,
@@ -387,7 +389,7 @@ class AuthJWT(AuthConfig):
             algorithm=algorithm,
             headers=headers,
             audience=audience,
-            user_claims=user_claims,
+            user_claims=user_claims | pair_identifier,
             issuer=self._encode_issuer,
         )
         return {"access_token": access, "refresh_token": refresh}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "libre-fastapi-jwt"
-version = "0.20.4"
+version = "0.20.5"
 description = "Yet another fork of fast-jwt-auth"
 authors = ["Libre NZ <github-support@libre.nz>"]
 license = "MIT"
@@ -14,7 +14,6 @@ classifiers = [
   "Environment :: Web Environment",
   "Intended Audience :: Developers",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
* Removed unused variable
* Made `set_pair_cookies()` to merge user_claim Dict instead of relying on default value
* Drop Python 3.8 from support due to the above Dict merge method